### PR TITLE
Fix .bazelrc to get bazel query //... working with Bazel 5.0.0

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -16,9 +16,7 @@ build:linux --host_cxxopt=-std=c++20
 
 startup --windows_enable_symlinks 
 build --enable_runfiles
-query --enable_runfiles
 build --nolegacy_external_runfiles
-query --nolegacy_external_runfiles
 build --experimental_worker_allow_json_protocol
 build --experimental_worker_cancellation
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -5,22 +5,24 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 http_archive(
     name = "bzlws",
-    strip_prefix = "bzlws-f929e5380f441f50a77776d34a7df8cacdbdf986",
-    url = "https://github.com/zaucy/bzlws/archive/f929e5380f441f50a77776d34a7df8cacdbdf986.zip",
-    sha256 = "5bebb821b158b11d81dd25cf031b5b26bae97dbb02025df7d0e41a262b3a030b",
+    sha256 = "1cfcdca3c67ff760000843df9d050946da52a7d50a9fc6e7877f3fcea283db83",
+    strip_prefix = "bzlws-a8f3e4b0bc168059ec92971b1ea7c214db2c5454",
+    url = "https://github.com/zaucy/bzlws/archive/a8f3e4b0bc168059ec92971b1ea7c214db2c5454.zip",
 )
 
 load("@bzlws//:repo.bzl", "bzlws_deps")
+
 bzlws_deps()
 
 git_repository(
     name = "io_bazel_stardoc",
-    remote = "https://github.com/bazelbuild/stardoc.git",
     commit = "f4d4b3a965c9ae36feeff5eb3171d6ba17406b84",
+    remote = "https://github.com/bazelbuild/stardoc.git",
     shallow_since = "1636567136 -0500",
 )
 
 load("@io_bazel_stardoc//:setup.bzl", "stardoc_repositories")
+
 stardoc_repositories()
 
 load("//:repo.bzl", "blender_repository")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -16,8 +16,8 @@ bzlws_deps()
 git_repository(
     name = "io_bazel_stardoc",
     remote = "https://github.com/bazelbuild/stardoc.git",
-    commit = "247c2097e7346778ac8d03de5a4770d6b9890dc5",
-    shallow_since = "1600270745 -0400",
+    commit = "f4d4b3a965c9ae36feeff5eb3171d6ba17406b84",
+    shallow_since = "1636567136 -0500",
 )
 
 load("@io_bazel_stardoc//:setup.bzl", "stardoc_repositories")

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,7 @@
 <!-- Generated with Stardoc: http://skydoc.bazel.build -->
 
+
+
 <a id="#blender_library"></a>
 
 ## blender_library
@@ -8,7 +10,7 @@
 blender_library(<a href="#blender_library-name">name</a>, <a href="#blender_library-srcs">srcs</a>)
 </pre>
 
-Group .blend files together to be used as `deps` in `blender_render`. Usually used when the .blend files in `srcs` are linked to a .blend file in `blender_render`.
+Group .blend files and images together to be used as `deps` in `blender_render`.
 
 **ATTRIBUTES**
 
@@ -16,7 +18,7 @@ Group .blend files together to be used as `deps` in `blender_render`. Usually us
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="blender_library-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
-| <a id="blender_library-srcs"></a>srcs |  List of blend files   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | required |  |
+| <a id="blender_library-srcs"></a>srcs |  List of blend files and image files   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | required |  |
 
 
 <a id="#blender_render"></a>
@@ -24,9 +26,9 @@ Group .blend files together to be used as `deps` in `blender_render`. Usually us
 ## blender_render
 
 <pre>
-blender_render(<a href="#blender_render-name">name</a>, <a href="#blender_render-autoexec_scripts">autoexec_scripts</a>, <a href="#blender_render-batch_render">batch_render</a>, <a href="#blender_render-blend_file">blend_file</a>, <a href="#blender_render-blender_executable">blender_executable</a>, <a href="#blender_render-deps">deps</a>,
-               <a href="#blender_render-factory_startup">factory_startup</a>, <a href="#blender_render-frame_end">frame_end</a>, <a href="#blender_render-frame_start">frame_start</a>, <a href="#blender_render-python_script_args">python_script_args</a>, <a href="#blender_render-python_scripts">python_scripts</a>,
-               <a href="#blender_render-render_engine">render_engine</a>, <a href="#blender_render-render_format">render_format</a>, <a href="#blender_render-scene">scene</a>)
+blender_render(<a href="#blender_render-name">name</a>, <a href="#blender_render-batch_render">batch_render</a>, <a href="#blender_render-blend_file">blend_file</a>, <a href="#blender_render-blender_executable">blender_executable</a>, <a href="#blender_render-deps">deps</a>,
+               <a href="#blender_render-enable_cycles_devices_script">enable_cycles_devices_script</a>, <a href="#blender_render-frame_end">frame_end</a>, <a href="#blender_render-frame_start">frame_start</a>, <a href="#blender_render-python_script_args">python_script_args</a>,
+               <a href="#blender_render-python_scripts">python_scripts</a>, <a href="#blender_render-render_engine">render_engine</a>, <a href="#blender_render-render_format">render_format</a>, <a href="#blender_render-scene">scene</a>)
 </pre>
 
 Render a .blend file in to a list of frames
@@ -37,12 +39,11 @@ Render a .blend file in to a list of frames
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="blender_render-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
-| <a id="blender_render-autoexec_scripts"></a>autoexec_scripts |  Enable automatic Python script execution   | Boolean | optional | False |
 | <a id="blender_render-batch_render"></a>batch_render |  Number of frames to render at a time. If <code>0</code> all the frames will be rendered at once.   | Integer | optional | 0 |
 | <a id="blender_render-blend_file"></a>blend_file |  Blend file to render   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
 | <a id="blender_render-blender_executable"></a>blender_executable |  Blender executable to use for the render.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | @blender//:blender |
 | <a id="blender_render-deps"></a>deps |  <code>blender_library</code> dependencies   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
-| <a id="blender_render-factory_startup"></a>factory_startup |  Pass --factory-startup to blender. It is not recommended to set this to <code>False</code> since blender will access the machines HOME directory potentially breaking the render.   | Boolean | optional | True |
+| <a id="blender_render-enable_cycles_devices_script"></a>enable_cycles_devices_script |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | @blender//:enable_cycles_devices.py |
 | <a id="blender_render-frame_end"></a>frame_end |  End frame in animation   | Integer | required |  |
 | <a id="blender_render-frame_start"></a>frame_start |  Start frame in animation   | Integer | required |  |
 | <a id="blender_render-python_script_args"></a>python_script_args |  Arguments to pass to blender after '--'. Typically handled by the script the <code>python_script</code> attribute.   | List of strings | optional | [] |

--- a/docs/repo.md
+++ b/docs/repo.md
@@ -1,11 +1,14 @@
 <!-- Generated with Stardoc: http://skydoc.bazel.build -->
 
+
+
 <a id="#blender_repository"></a>
 
 ## blender_repository
 
 <pre>
-blender_repository(<a href="#blender_repository-name">name</a>, <a href="#blender_repository-blender_version">blender_version</a>, <a href="#blender_repository-only_system_installed_blender">only_system_installed_blender</a>, <a href="#blender_repository-repo_mapping">repo_mapping</a>)
+blender_repository(<a href="#blender_repository-name">name</a>, <a href="#blender_repository-blender_version">blender_version</a>, <a href="#blender_repository-cycles_device_types">cycles_device_types</a>, <a href="#blender_repository-only_system_installed_blender">only_system_installed_blender</a>,
+                   <a href="#blender_repository-repo_mapping">repo_mapping</a>)
 </pre>
 
 
@@ -16,7 +19,8 @@ blender_repository(<a href="#blender_repository-name">name</a>, <a href="#blende
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="blender_repository-name"></a>name |  A unique name for this repository.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
-| <a id="blender_repository-blender_version"></a>blender_version |  Blender version. Used to download blender archive.   | String | optional | "3.0.0" |
+| <a id="blender_repository-blender_version"></a>blender_version |  Blender version. Used to download blender archive.   | String | optional | "3.0.1" |
+| <a id="blender_repository-cycles_device_types"></a>cycles_device_types |  -   | List of strings | optional | [] |
 | <a id="blender_repository-only_system_installed_blender"></a>only_system_installed_blender |  -   | Boolean | optional | False |
 | <a id="blender_repository-repo_mapping"></a>repo_mapping |  A dictionary from local repository name to global repository name. This allows controls over workspace dependency resolution for dependencies of this repository.&lt;p&gt;For example, an entry <code>"@foo": "@bar"</code> declares that, for any time this repository depends on <code>@foo</code> (such as a dependency on <code>@foo//some:target</code>, it should actually resolve that dependency within globally-declared <code>@bar</code> (<code>@bar//some:target</code>).   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | required |  |
 


### PR DESCRIPTION
This PR...

1. Fixes an issue with .bazelrc:
`bazel query //... ` using Bazel 5.0.0 leads on master to:

```
INFO: Reading rc options for 'query' from /home/vertexwahn/dev/rules_blender/.bazelrc:
  'query' options: --enable_runfiles
ERROR: --enable_runfiles :: Unrecognized option: --enable_runfiles
```
`--enable_runfiles` was removed - see [here](https://www.buildbuddy.io/blog/whats-new-in-bazel-5-0/). Similar for `--nolegacy_external_runfiles`

2. Update stardoc to newest commit hash. Regenerate documentation.

3. Update bzlws to newest commit hash